### PR TITLE
Add schema and passing examples for BMO simple ping

### DIFF
--- a/schemas/eng-workflow/bmobugs/bmobugs.1.schema.json
+++ b/schemas/eng-workflow/bmobugs/bmobugs.1.schema.json
@@ -1,0 +1,146 @@
+{
+   "$schema" : "http://json-schema.org/draft-04/schema#",
+   "additionalProperties" : false,
+   "properties" : {
+      "assigned_to" : {
+         "type" : "integer"
+      },
+      "blocked_by" : {
+         "items" : {
+            "type" : "integer"
+         },
+         "type" : "array"
+      },
+      "bug_id" : {
+         "minimum" : 1,
+         "type" : "integer"
+      },
+      "bug_severity" : {
+         "type" : "string"
+      },
+      "bug_status" : {
+         "type" : "string"
+      },
+      "component" : {
+         "type" : "string"
+      },
+      "creation_ts" : {
+         "type" : "string"
+      },
+      "delta_ts" : {
+         "type" : "string"
+      },
+      "depends_on" : {
+         "items" : {
+            "type" : "integer"
+         },
+         "type" : "array"
+      },
+      "duplicate_of" : {
+         "type" : [
+            "null",
+            "integer"
+         ]
+      },
+      "duplicates" : {
+         "items" : {
+            "type" : "integer"
+         },
+         "type" : "array"
+      },
+      "flags" : {
+         "items" : {
+            "additionalProperties" : false,
+            "properties" : {
+               "name" : {
+                  "type" : "string"
+               },
+               "requestee_id" : {
+                  "type" : [
+                     "null",
+                     "integer"
+                  ]
+               },
+               "setter_id" : {
+                  "type" : "integer"
+               },
+               "status" : {
+                  "enum" : [
+                     "?",
+                     "+",
+                     "-"
+                  ],
+                  "type" : "string"
+               }
+            },
+            "required" : [
+               "status",
+               "name",
+               "setter_id",
+               "requestee_id"
+            ],
+            "type" : "object"
+         },
+         "type" : "array"
+      },
+      "groups" : {
+         "items" : {
+            "type" : "string"
+         },
+         "type" : "array"
+      },
+      "keywords" : {
+         "items" : {
+            "type" : "string"
+         },
+         "type" : "array"
+      },
+      "priority" : {
+         "type" : "string"
+      },
+      "product" : {
+         "type" : "string"
+      },
+      "qa_contact" : {
+         "type" : [
+            "null",
+            "integer"
+         ]
+      },
+      "reporter" : {
+         "type" : "integer"
+      },
+      "resolution" : {
+         "type" : "string"
+      },
+      "target_milestone" : {
+         "type" : "string"
+      },
+      "version" : {
+         "type" : "string"
+      }
+   },
+   "required" : [
+      "priority",
+      "blocked_by",
+      "duplicate_of",
+      "bug_id",
+      "reporter",
+      "keywords",
+      "duplicates",
+      "assigned_to",
+      "creation_ts",
+      "groups",
+      "qa_contact",
+      "bug_severity",
+      "depends_on",
+      "bug_status",
+      "delta_ts",
+      "flags",
+      "version",
+      "component",
+      "product",
+      "target_milestone"
+   ],
+   "type" : "object"
+}

--- a/validation/eng-workflow/bmobugs.1.flags.pass.json
+++ b/validation/eng-workflow/bmobugs.1.flags.pass.json
@@ -1,0 +1,30 @@
+{
+   "assigned_to" : 1,
+   "blocked_by" : [],
+   "bug_id" : 1526431,
+   "bug_severity" : "normal",
+   "bug_status" : "NEW",
+   "component" : "Testing",
+   "creation_ts" : "2019-02-08 11:09:58",
+   "delta_ts" : "2019-02-08T12:14:22",
+   "depends_on" : [],
+   "duplicate_of" : null,
+   "duplicates" : [],
+   "flags" : [
+      {
+         "name" : "needinfo",
+         "requestee_id" : 408096,
+         "setter_id" : 23402,
+         "status" : "?"
+      }
+   ],
+   "groups" : [],
+   "keywords" : [],
+   "priority" : "--",
+   "product" : "Firefox for Android",
+   "qa_contact" : null,
+   "reporter" : 474533,
+   "resolution" : "",
+   "target_milestone" : "---",
+   "version" : "unspecified"
+}

--- a/validation/eng-workflow/bmobugs.1.newer.pass.json
+++ b/validation/eng-workflow/bmobugs.1.newer.pass.json
@@ -1,0 +1,30 @@
+{
+   "assigned_to" : 1,
+   "blocked_by" : [
+      1526109
+   ],
+   "bug_id" : 1526430,
+   "bug_severity" : "normal",
+   "bug_status" : "NEW",
+   "component" : "Application Update",
+   "creation_ts" : "2019-02-08 11:09:26",
+   "delta_ts" : "2019-02-08T11:21:12",
+   "depends_on" : [
+      1524400
+   ],
+   "duplicate_of" : null,
+   "duplicates" : [],
+   "flags" : [],
+   "groups" : [],
+   "keywords" : [
+      "regression",
+      "intermittent-failure"
+   ],
+   "priority" : "P5",
+   "product" : "Toolkit",
+   "qa_contact" : null,
+   "reporter" : 573381,
+   "resolution" : "",
+   "target_milestone" : "---",
+   "version" : "unspecified"
+}

--- a/validation/eng-workflow/bmobugs.1.oldone.pass.json
+++ b/validation/eng-workflow/bmobugs.1.oldone.pass.json
@@ -1,0 +1,23 @@
+{
+   "assigned_to" : 99,
+   "blocked_by" : [],
+   "bug_id" : 200,
+   "bug_severity" : "trivial",
+   "bug_status" : "VERIFIED",
+   "component" : "Layout",
+   "creation_ts" : "1998-04-14 02:09:13",
+   "delta_ts" : "2008-11-21T13:41:32",
+   "depends_on" : [],
+   "duplicate_of" : null,
+   "duplicates" : [],
+   "flags" : [],
+   "groups" : [],
+   "keywords" : [],
+   "priority" : "P3",
+   "product" : "MozillaClassic Graveyard",
+   "qa_contact" : null,
+   "reporter" : 86,
+   "resolution" : "FIXED",
+   "target_milestone" : "---",
+   "version" : "1998-03-31"
+}


### PR DESCRIPTION
Here's the schema for the first version of the BMO Simple ping.
To fit in the eng-workflow namespace the doctype name is 'bmobugs'.

Note the schema has run against all bugs in the BMO database as of a
late-february snapshot. I provided 3 examples that cover most variations.

Checklist for reviewer:

- [ ] Scan the PR and verify that no changes (particularly to `.circleci/config.yml`) will cause environment variables (particularly credentials) to be exposed in test logs
- [ ] Trigger the `integration` CI test by pushing this revision [as discussed in the README](https://github.com/mozilla-services/mozilla-pipeline-schemas#packaging-and-integration-tests-optional)

For glean changes:
- [ ] Update `include/glean/CHANGELOG.md`